### PR TITLE
An exception is thrown in TransactionRepository::__construct() if $dir parameter is NULL

### DIFF
--- a/src/Transaction/TransactionRepository.php
+++ b/src/Transaction/TransactionRepository.php
@@ -54,7 +54,7 @@ class TransactionRepository implements TransactionRepositoryInterface
 
             default:
                 throw new \RuntimeException(
-                    "`dir` parameter must be a string or an object which implements Cache interface"
+                    "Parameter $dir must be NULL, a string or an object which implements Cache interface."
                 );
         }
     }

--- a/src/Transaction/TransactionRepository.php
+++ b/src/Transaction/TransactionRepository.php
@@ -31,10 +31,10 @@ class TransactionRepository implements TransactionRepositoryInterface
     /**
      * TransactionRepository constructor.
      *
-     * @param Serializer $serializer
-     * @param string     $prefix
-     * @param int        $timeInterval Time interval in minutes after which purchase should be returned as unfinished.
-     * @param string|Cache $dir  with this parameter you can also specify your own Cache object otherwise we'll use FilesystemCache
+     * @param Serializer        $serializer
+     * @param string            $prefix
+     * @param int               $timeInterval Time interval in minutes after which purchase should be returned as unfinished.
+     * @param string|Cache|null $dir with this parameter you can also specify your own Cache object otherwise we'll use FilesystemCache
      */
     public function __construct(Serializer $serializer, $prefix = '', $timeInterval = 30, $dir = null)
     {
@@ -48,7 +48,7 @@ class TransactionRepository implements TransactionRepositoryInterface
                 break;
 
             case is_string($dir):
-            case null:
+            case is_null($dir):
                 $this->fileCache = new FilesystemCache($dir ? $dir : sys_get_temp_dir() . '/banklink');
                 break;
 


### PR DESCRIPTION
This fixes a bug in `\SwedbankPaymentPortal\Transaction\TransactionRepository::__construct()` where check against the type of `$dir` parameter will never catch `NULL` value and will always switch to `default` case which throws an exception. 

```php
switch (true) {
  case is_string($dir):
  case null: // <- This case will never trigger.
    $this->fileCache = new FilesystemCache($dir ? $dir : sys_get_temp_dir() . '/banklink');
    break;
  default:
    throw new \RuntimeException(
      "`dir` parameter must be a string or an object which implements Cache interface"
    );
}
```
The solution is to check for `null` type and go from there.

```php
switch (true) {
  case is_string($dir):
  case is_null($dir):
    // ...
```

This bug breaks backwards compatibility as implementations that don't use custom cache cease to work:

> RuntimeException: `dir` parameter must be a string or an object which implements Cache interface in SwedbankPaymentPortal\Transaction\TransactionRepository->__construct() (line 56 of /var/www/[snip]/vendor/swedbank-spp/swedbank-payment-portal/src/Transaction/TransactionRepository.php).
