### PR TITLE
HPS code example updated (country name changed to country code).

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ $riskAction = new Transaction\Action(
         'Street address', // address line 1
         '', // address line 2
         'London', // City
-        'Unated States' // Country
+        'GB' // Country code
         ), new Transaction\PersonalDetails(// Personal details
         'Name', // Required, Card holder name
         'Surname', // Required. Card holder surname
@@ -470,7 +470,7 @@ $riskAction = new Transaction\Action(
         'Street address', // address line 1
         '', // address line 2
         'City', // City
-        'Unated Kingdom', // Country
+        'GB', // Country code
         'Zip0000' // Post code
         ), new Transaction\RiskDetails(
         '127.15.21.55', // Required. Card holder IP address
@@ -606,7 +606,7 @@ $riskAction = new Transaction\Action(
             'Street address', // address line 1
             '', // address line 2
             'London', // City
-            'Unated States' // Country
+            'GB' // Country code
         ),
         new Transaction\PersonalDetails( // Personal details
             'Name', // Required, Card holder name
@@ -621,7 +621,7 @@ $riskAction = new Transaction\Action(
             'Street address', // address line 1
             '', // address line 2
             'City', // City
-            'Unated Kingdom', // Country
+            'GB', // Country code
             'Zip0000' // Post code
         ),
 


### PR DESCRIPTION
This change updates HPS code example `README.md` with indication that value of `country` in customer's details should be a country code, not human readable name.

Original issue: https://github.com/Swedbank-SPP/swedbank-payment-portal/issues/6