### PR TITLE
Ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Composer PHAR
 /composer.phar
+/composer.lock
 
 # Test output
 /tmp


### PR DESCRIPTION
Running `$ composer install` creates a `composer.lock` file, which should be git-ignored for packages.

I added the rule so no one can mistakenly push to origin.